### PR TITLE
Fix/repeat announcements not working

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -32,7 +32,7 @@ class App extends Component {
         <Announcer text={this.state.announcement} />
         <div className="App-header">
           <h2>Basic Announcer Example</h2>
-          <button type="button" onClick={ () => this.handleClick('test')}>Trigger new announcement</button>
+          <button type="button" onClick={ () => this.handleClick('Here\'s a new announcement!')}>Trigger new announcement</button>
         </div>
       </div>
     );

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -14,15 +14,9 @@ class App extends Component {
     this.handleClick = this.handleClick.bind(this);
   }
 
-  handleClick(announcementText) {
-    const currentAnnouncement = this.state.announcement;
-
-    if (announcementText === currentAnnouncement) {
-      announcementText = announcementText + '\u00A0';
-    }
-
+  handleClick() {
     this.setState(prevState => ({
-      announcement: announcementText
+      announcement: 'Here\'s a new announcement!'
     }));
   }
 
@@ -32,7 +26,7 @@ class App extends Component {
         <Announcer text={this.state.announcement} />
         <div className="App-header">
           <h2>Basic Announcer Example</h2>
-          <button type="button" onClick={ () => this.handleClick('Here\'s a new announcement!')}>Trigger new announcement</button>
+          <button type="button" onClick={this.handleClick}>Trigger new announcement</button>
         </div>
       </div>
     );

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -14,9 +14,15 @@ class App extends Component {
     this.handleClick = this.handleClick.bind(this);
   }
 
-  handleClick() {
+  handleClick(announcementText) {
+    const currentAnnouncement = this.state.announcement;
+
+    if (announcementText === currentAnnouncement) {
+      announcementText = announcementText + '\u00A0';
+    }
+
     this.setState(prevState => ({
-      announcement: 'Here\'s a new announcement!'
+      announcement: announcementText
     }));
   }
 
@@ -26,7 +32,7 @@ class App extends Component {
         <Announcer text={this.state.announcement} />
         <div className="App-header">
           <h2>Basic Announcer Example</h2>
-          <button type="button" onClick={this.handleClick}>Trigger new announcement</button>
+          <button type="button" onClick={ () => this.handleClick('test')}>Trigger new announcement</button>
         </div>
       </div>
     );

--- a/src/Announcer.js
+++ b/src/Announcer.js
@@ -2,13 +2,32 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class Announcer extends Component {
+
+    constructor(props) {
+      super(props);
+      this.state = {
+        text: ''
+      }
+    }
+
     static propTypes = {
-        text: PropTypes.string,
-        politeness: PropTypes.string
+      text: PropTypes.string,
+      politeness: PropTypes.string
     }
 
     static defaultProps = {
-        politeness: 'polite'
+      politeness: 'polite'
+    }
+
+    componentWillReceiveProps(nextProps) {
+      const currentAnnouncement = this.state.text;
+      let nextAnnouncement = nextProps.text;
+      if (nextAnnouncement === currentAnnouncement) {
+        nextAnnouncement = nextAnnouncement + '\u00A0';
+      }
+      this.setState(prevState => ({
+        text: nextAnnouncement
+      }));
     }
 
     defaultStyles = {
@@ -29,16 +48,15 @@ class Announcer extends Component {
     render() {
         const { className, text, politeness } = this.props;
         const styles = className ? {} : this.defaultStyles;
-
         return (
-            <div 
+            <div
                 aria-live={politeness}
                 style={styles}
                 className={className}
             >
                 {
-                    text.length ?
-                    <p>{text}</p> :
+                    this.state.text.length ?
+                    <p>{this.state.text}</p> :
                     null
                 }
             </div>


### PR DESCRIPTION
#### What is this PR for?
This solves the issue where some screen readers, such as VoiceOver, don't repeat an announcement if the text remains the same. It checks to see if the message is the same as what is currently within the components state, and then if it is the same it appends the string with a non-breaking space. I've seen this solution used a couple of times before for the same problem. 

#### Where should the reviewer start?

1. Open up your local environment and go to the basic test page here: http://127.0.0.1:8080/basic/

#### What should the reviewer look at?

1. Start VoiceOver (or any other screen reader tool)
1. Click on the `Trigger New Announcement` button
1. You should hear an announcement
1. Click on the button again
1. You should hear the same announcement again.

#### What gif best describes this PR or how it makes you feel?
![Joke gif about the a11y announcer](https://media.giphy.com/media/wWqxq40b710go/giphy.gif)

#### Additional comments:

I'm still fairly new to React so please let me know if I am breaking any rules here.

#### Definition of Done:
- [❓] Is there appropriate test coverage?
- [❓] Does this pass all automatic linting?
- [❓] Does the documentation need to be updated?
- [❌] Does this add new dependencies?

