### PR TITLE
Add aria-atomic attribute; Add object rest and spread of props

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
     "presets": ["es2015", "react"],
     "plugins": [
-        "transform-class-properties"
+        "transform-class-properties",
+        "transform-object-rest-spread"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-jest": "^20.0.3",
     "babel-loader": "^7.1.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "enzyme": "^2.9.1",

--- a/src/Announcer.js
+++ b/src/Announcer.js
@@ -2,9 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class Announcer extends Component {
-
     constructor(props) {
       super(props);
+  
       this.state = {
         text: ''
       }
@@ -22,9 +22,11 @@ class Announcer extends Component {
     componentWillReceiveProps(nextProps) {
       const currentAnnouncement = this.state.text;
       let nextAnnouncement = nextProps.text;
+  
       if (nextAnnouncement === currentAnnouncement) {
         nextAnnouncement = nextAnnouncement + '\u00A0';
       }
+  
       this.setState(prevState => ({
         text: nextAnnouncement
       }));
@@ -46,13 +48,15 @@ class Announcer extends Component {
     }
 
     render() {
-        const { className, text, politeness } = this.props;
+        const { className, text, politeness, ...props } = this.props;
         const styles = className ? {} : this.defaultStyles;
         return (
             <div
+                aria-atomic
                 aria-live={politeness}
                 style={styles}
                 className={className}
+                {...props}
             >
                 {
                     this.state.text.length ?


### PR DESCRIPTION
Adding the `aria-atomic` attribute to the `<Announcer />` as well as spreading additional props passed in by the consumer to the component. Requires [transform-object-rest-spread](https://babeljs.io/docs/plugins/transform-object-rest-spread/) Babel plugin. Also added a few line breaks for better readability.