### PR TITLE
Allow remote access of local dev server 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/Announcer.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --hot --host 127.0.0.1 --content-base examples/",
+    "start": "webpack-dev-server",
     "build": "rimraf dist && mkdirp dist && babel src -d dist",
     "test": "jest",
     "prepublish": "npm run build"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,21 +32,29 @@ module.exports = {
     path: EXAMPLES_DIR + '/__build__',
     publicPath: '/__build__/'
   },
-
     module: {
     rules: [
         {
-        test: /\.js$/,
-        exclude: /(node_modules)/,
-        use: {
-            loader: 'babel-loader'
-        }
+          test: /\.js$/,
+          exclude: /(node_modules)/,
+          use: {
+              loader: 'babel-loader'
+          }
         }
     ]
     },
 
   plugins: [
     new webpack.optimize.CommonsChunkPlugin({name: 'shared', minChunks: Infinity})
-  ]
-
+  ],
+  devServer: {
+    host: '0.0.0.0',
+    contentBase: 'examples/',
+    port: 8080,
+    disableHostCheck: true,
+    inline: false,
+    hot: true
+  }
 };
+
+///--inline --hot --content-base examples/


### PR DESCRIPTION
#### What is this PR for?

It fixes an issue where a developer cannot use external devices to access the webpack server for testing/debugging purposes. If you needed to test on a physical device or if you needed to use a VM to run another OS, you couldn't access the local server. 

#### Where should the reviewer start?

1. Pull in the code and start up the server

#### What should the reviewer look at?

1. Use Parallels, your phone, another computer and then access the server using your devices network public IP

#### Additional comments:

The one consideration I wanted to be mindful of is if this could be a potential security risk. It looks like webpack intentionally prevents remote access from a different host, but given that the intent is for testing purposes, I think that is okay. The other option would be to use a separate server for testing than for the demo. I don't see this as being too much of a concern. 
