### PR TITLE
update npm start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/Announcer.js",
   "scripts": {
-    "start": "webpack-dev-server",
+    "start": "webpack serve",
     "build": "rimraf dist && mkdirp dist && babel src -d dist",
     "test": "jest",
     "test:updateSnapshot": "jest --updateSnapshot",


### PR DESCRIPTION
npm script is broken and gives an error when you try running it on you local environment.

**Error Message when running npm start:**
```
Error: Cannot find module 'webpack-cli/bin/config-yargs'
Require stack:
../react-a11y-announcer/node_modules/webpack-dev-server/bin/webpack-dev-server.js
```

It looks like we are on `"webpack-cli": "^4.1.0",`, which now requires an updated command for `npm start` to work properly.

**The fix was to change the following in package.json:**
```
"scripts": { "start": "webpack-dev-server" }
```
to
```
"scripts": { "start": "webpack serve" }
```